### PR TITLE
Pantalla de proveedores y progreso en los proyectos

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import {
 } from '@material-ui/icons';
 import { Presupuestos } from './components/Presupuestos';
 import { Compras } from './components/Compras';
+import { Proveedores } from './components/Proveedores'
 
 export default function App() {
   const $ = useStyles();
@@ -21,7 +22,7 @@ export default function App() {
   const sideBarOptions = [
     { text: 'Proyectos', icon: <Home />, path: '/datos' },
     { text: 'Presupuesto', icon: <AttachMoney />, path: '/presupuesto' },
-    { text: 'Proveedores', icon: <AssignmentInd />, path: '/' },
+    { text: 'Proveedores', icon: <AssignmentInd />, path: '/proveedores' },
     { text: 'Normativas I+D', icon: <Info />, path: '/' },
     { text: 'Soporte', icon: <Help />, path: '/' },
   ];
@@ -38,7 +39,7 @@ export default function App() {
               <Route path="/proyectos" exact component={DatosGenerales} />
               <Route path="/proyectos/presupuestos" exact component={Presupuestos} />
               <Route path="/proyectos/compras" exact component={Compras} />
-              
+              <Route path="/proyectos/proveedores" exact component={Proveedores} />
             </Switch>
           </div>
         </div>

--- a/src/components/CircularProgressWithValue.jsx
+++ b/src/components/CircularProgressWithValue.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+
+export const CircularProgressWithValue = (props) => {
+    return (
+      <Box position="relative" display="inline-flex">
+        <CircularProgress variant="determinate" value={props.progreso} />
+        <Box
+          top={0}
+          left={0}
+          bottom={0}
+          right={0}
+          position="absolute"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Typography variant="caption" color="textSecondary">{`${props.progreso}%`}</Typography>
+        </Box>
+      </Box>
+    );
+  }

--- a/src/components/Compras.jsx
+++ b/src/components/Compras.jsx
@@ -9,7 +9,7 @@ import { withStyles, makeStyles } from '@material-ui/core/styles';
 import Alert from '@material-ui/lab/Alert';
 import Divider from '@material-ui/core/Divider';
 import { Button, Grid,Modal } from '@material-ui/core';
-import PopUp from './PopUp';
+import PopUpCompras from './PopUpCompras';
 import { Footer } from './Footer';
 
 const StyledTableCell = withStyles((theme) => ({
@@ -74,7 +74,7 @@ export const Compras = (props) => {
   const loadingRendering = () => {
       return <Alert severity="info">Cargando...</Alert>;
     };
-    const rendering = () =>{
+    const rendering = () => {
       return(
       <>
       <TableContainer className={$.container}>
@@ -118,7 +118,7 @@ export const Compras = (props) => {
               open={open}
               onClose={handleClose}
           >
-            <PopUp state={setOpen}/>
+            <PopUpCompras state={setOpen}/>
           </Modal>
       </Grid>
       <Divider/>
@@ -130,14 +130,13 @@ export const Compras = (props) => {
 }
 const useStyles = makeStyles({
   container: {
-      width: '100%'
+    width: '100%'
   },
-  header:{
+  header: {
     display: 'flex',
     justifyContent: 'space-between'
   },
-  button:{
-    width: '10rem',
+  button: {
     height: '2rem',
     marginTop: '1.5rem'
   },

--- a/src/components/DatosGenerales.jsx
+++ b/src/components/DatosGenerales.jsx
@@ -106,7 +106,7 @@ export const DatosGenerales = () => {
           />
         </ListItem>
         <ListItem className={$.dropDown} button>
-          <ListItemText primary={'Integrantes'} />
+          <ListItemText primary={'Integrantes'} onClick={handleClick} />
           <ExpandMoreIcon onClick={handleClick} sx={{ ml: 1 }} />
           <Menu
             id="simple-menu"

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -5,21 +5,21 @@ export const Footer = () => {
     const $ = useStyles()
 
     return <>
-        <div className={$.footer}>
-        <Divider />
-        <br />
-        <Typography variant="body2" className={$.texto}>
-          Esta aplicación ha sido realizada por estudiantes de la Licenciatura
-          en Informática de la UNaHur.
-        </Typography>
+    <div className={$.footer}>
+      <Divider />
+      <br />
+      <Typography variant="body2" className={$.texto}>
+        Esta aplicación ha sido realizada por estudiantes de la Licenciatura
+        en Informática de la UNaHur.
+      </Typography>
 
-        <Typography variant="body2" className={$.texto}>
-          Si encontraste algún error o querés ver el código fuente, podés
-          acceder a la organización de{' '}
-          <a href="https://github.com/ControlGastosSubsidios">GitHub</a> del proyecto.
-        </Typography>
-        <br />
-      </div>
+      <Typography variant="body2" className={$.texto}>
+        Si encontraste algún error o querés ver el código fuente, podés
+        acceder a la organización de{' '}
+        <a href="https://github.com/ControlGastosSubsidios">GitHub</a> del proyecto.
+      </Typography>
+      <br />
+    </div>
     </>
 }
 
@@ -28,6 +28,8 @@ const useStyles = makeStyles((theme) => ({
       left: 0,
       width: '100%',
       textAlign: 'center',
+      alignSelf: 'flex-end'
+
     },
     texto: {
       color: theme.palette.text.secondary,

--- a/src/components/MisProyectos.jsx
+++ b/src/components/MisProyectos.jsx
@@ -11,6 +11,7 @@ import { proyectosEnCurso } from '../constants/constants';
 import { proyectosEnHistoria } from '../constants/constants';
 import { proyectoPrueba } from '../constants/constants';
 import { Link } from 'react-router-dom';
+import { CircularProgressWithValue } from './CircularProgressWithValue';
 
 const StyledTableCell = withStyles((theme) => ({
   head: {
@@ -73,15 +74,19 @@ export const MisProyectos = () => {
                   </StyledTableCell>
                   <StyledTableCell align="center">{proyectoPrueba.director}</StyledTableCell>
                   <StyledTableCell align="center">{proyectoPrueba.fechaInicio}</StyledTableCell>
-                  <StyledTableCell align="center">{'50%'}</StyledTableCell>
+                  <StyledTableCell align="center">
+                    <CircularProgressWithValue progreso={50} />
+                  </StyledTableCell>
                 </StyledTableRow>
 
                 {proyectosEnCurso.map((proyectosEnCurso) => (
                     <StyledTableRow key={proyectosEnCurso.nombre}>
-                    <StyledTableCell scope="row">{proyectosEnCurso.nombre}</StyledTableCell>
-                    <StyledTableCell align="center">{proyectosEnCurso.director}</StyledTableCell>
-                    <StyledTableCell align="center">{proyectosEnCurso.fechaInicio}</StyledTableCell>
-                    <StyledTableCell align="center">{proyectosEnCurso.porcentaje}</StyledTableCell>
+                      <StyledTableCell scope="row">{proyectosEnCurso.nombre}</StyledTableCell>
+                      <StyledTableCell align="center">{proyectosEnCurso.director}</StyledTableCell>
+                      <StyledTableCell align="center">{proyectosEnCurso.fechaInicio}</StyledTableCell>
+                      <StyledTableCell align="center">
+                        <CircularProgressWithValue progreso={proyectosEnCurso.porcentaje} />
+                      </StyledTableCell>
                     </StyledTableRow>
                 ))}
                 </TableBody>
@@ -103,7 +108,9 @@ export const MisProyectos = () => {
                     <StyledTableCell scope="row" className={ $.tableCellContent }>{proyectosEnHistoria.nombre}</StyledTableCell>
                     <StyledTableCell align="center">{proyectosEnHistoria.director}</StyledTableCell>
                     <StyledTableCell align="center">{proyectosEnHistoria.fechaInicio}</StyledTableCell>
-                    <StyledTableCell align="center">{proyectosEnHistoria.porcentaje}</StyledTableCell>
+                    <StyledTableCell align="center">
+                      <CircularProgressWithValue progreso={proyectosEnHistoria.porcentaje} />
+                    </StyledTableCell>
                     </StyledTableRow>
                 ))}
                 </TableBody>

--- a/src/components/PopUpCompras.jsx
+++ b/src/components/PopUpCompras.jsx
@@ -59,7 +59,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function PopUp(props) {
+export default function PopUpCompras(props) {
   const $ = useStyles();
 
   const submitForm = () => {

--- a/src/components/PopUpProveedores.jsx
+++ b/src/components/PopUpProveedores.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import {
+  makeStyles,
+  TextField,
+  Button,
+  Divider,
+  Grid,
+  Typography,
+} from '@material-ui/core';
+
+const useStyles = makeStyles((theme) => ({
+  modal: {
+    position: 'absolute',
+    backgroundColor: 'white',
+    width: '75vw',
+    height: '80vh',
+    boxShadow: '0px 0px 5px 1px grey',
+    padding: theme.spacing(2, 4, 3),
+    top: '55%',
+    left: '55%',
+    transform: 'translate(-50%,-50%)',
+  },
+  inputs: {
+    width: '100%',
+    paddingBottom: '1rem',
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+  item: {
+    paddingLeft: '1rem',
+  },
+  button: {
+    display: 'flex',
+    position: 'fixed',
+    bottom: '0',
+    right: '0',
+    height: '3rem',
+    marginBottom: '2rem',
+    marginRight: '2rem',
+  },
+  secondRow: {
+    display: 'grid',
+    width: '30%',
+  },
+  cargarFactura: {
+    display: 'flex',
+  },
+  descripcion: {
+    display: 'grid',
+    marginTop: '1.5rem',
+  },
+  multiLineInput: {
+    backgroundColor: '#fafafa',
+    borderRadius: '5px',
+    width: '90%',
+  },
+  proveedor: {
+    marginTop: '1.5rem',
+  },
+}));
+
+export default function PopUpCompras(props) {
+  const $ = useStyles();
+
+  const submitForm = () => {
+    props.state(false);
+    //Enviar data al backend
+  };
+  const handleClose = () => {
+    props.state(false);
+  };
+  return (
+    <>
+      <div className={$.modal}>
+        <h2>Realizar Pedido de Compra</h2>
+        <Divider />
+        <div className={$.inputs}>
+          <TextField label="Rubro" />
+          <TextField label="Subrubro" />
+        </div>
+        <Typography>Cuentas con $60.000 para este rubro </Typography>
+        <br />
+        <Divider />
+        <div className={$.secondRow}>
+          <TextField label="Fecha" />
+          <div className={$.cargarFactura}>
+            <TextField label="Monto" />
+            <Button color="primary" sx={{ minWidth: 100 }}>
+              Cargar Factura
+            </Button>
+          </div>
+        </div>
+        <div className={$.descripcion}>
+          <Typography variant="h5">Descripcion</Typography>
+          <br />
+          <TextField
+            label="La compra cuenta con los siguientes objetos/servicios"
+            multiline
+            rows={6}
+            className={$.multiLineInput}
+          />
+        </div>
+        <div className={$.cargarFactura}>
+          <TextField label="Proveedor" className={$.proveedor} />
+          <Button color="primary" sx={{ minWidth: 100 }}>
+            Proveedor Nuevo
+          </Button>
+        </div>
+
+        <div className={$.button}>
+          <Button color="primary" className={$.botones} onClick={handleClose}>
+            Cancelar
+          </Button>
+          <Button color="primary" onClick={submitForm}>
+            Finalizar Pedido de Compra
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/Proveedores.jsx
+++ b/src/components/Proveedores.jsx
@@ -1,0 +1,144 @@
+import { React, useState, useEffect }from 'react';
+import { Footer } from './Footer';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+import { withStyles, makeStyles } from '@material-ui/core/styles';
+import Alert from '@material-ui/lab/Alert';
+import Divider from '@material-ui/core/Divider';
+import { Button, Grid, Modal } from '@material-ui/core';
+import PopUp from './PopUpCompras';
+import { getProveedores } from '../services/proveedores';
+
+const StyledTableCell = withStyles((theme) => ({
+  head: {
+    backgroundColor: theme.palette.common.black,
+    color: theme.palette.common.white,
+  },
+  body: {
+    fontSize: 14,
+  },
+}))(TableCell);
+
+
+const StyledTableRow = withStyles((theme) => ({
+  root: {
+    '&:nth-of-type(odd)': {
+      backgroundColor: 'theme.palette.action.hover,'
+    },
+  },
+}))(TableRow);
+
+const StyledTableHead = withStyles((theme) => ({
+  root: {
+    '&:nth-of-type(odd)': {
+      backgroundColor: '#5AA123'
+    },
+  },
+}))(TableRow);
+
+
+export const Proveedores = () => {
+    const $ = useStyles();
+    const [proveedores, setProveedores] = useState(null);
+    const [open, setOpen] = useState(false);
+
+    const handleOpen = () => {
+        setOpen(true);
+      };
+    
+      const handleClose = () => {
+        setOpen(false);
+      };
+    
+    const loadingRendering = () => {
+        return <Alert severity="info">Cargando...</Alert>;
+    };
+    const rendering = () => {
+        return (
+            <>
+            <TableContainer className={$.container} component={Paper}>
+                <Table aria-label="customized table">
+                    <StyledTableHead>
+                        <StyledTableCell className={ $.textColor }>Nombre</StyledTableCell>
+                        <StyledTableCell align="center" className={ $.textColor }>Rubro</StyledTableCell>
+                        <StyledTableCell align="center" className={ $.textColor }>Teléfono</StyledTableCell>
+                        <StyledTableCell align="center" className={ $.textColor }>E-Mail</StyledTableCell>
+                        <StyledTableCell align="center" className={ $.textColor }>CUIT</StyledTableCell>
+                    </StyledTableHead>
+                    <TableBody>
+                    {proveedores.map((proveedores) => (
+                        <StyledTableRow key={proveedores.nombre}>
+                        <StyledTableCell scope="row">{proveedores.nombre}</StyledTableCell>
+                        <StyledTableCell align="center">{proveedores.rubro}</StyledTableCell>
+                        <StyledTableCell align="center">{proveedores.telefono}</StyledTableCell>
+                        <StyledTableCell align="center">{proveedores.mail}</StyledTableCell>
+                        <StyledTableCell align="center">{proveedores.cuit}</StyledTableCell>
+                        </StyledTableRow>
+                    ))}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+            </>
+        )
+    }
+
+    useEffect(() => {
+        async function fetchProveedores() {
+          const getFunction = getProveedores;
+          try {
+            const proveedores = await getFunction();
+            setProveedores(proveedores);
+          } catch (err) {
+            console.log('ERROR FETCH API [proveedores]: ' + err);
+          }
+        }
+        fetchProveedores();
+      }, []);
+      
+
+    return <>
+        <Grid className={$.header}>
+        <h1 className={$.title}>Proveedores</h1>
+        <Button variant="contained" className={$.button} onClick={handleOpen}>Agregar proveedor</Button>
+        <Modal
+            open={open}
+            onClose={handleClose}
+          >
+            <PopUp state={setOpen}/>
+        </Modal>
+        </Grid>
+        <Divider/>
+        <br/>
+        {proveedores? rendering() : loadingRendering}
+        <Footer />
+        </>
+}
+
+const useStyles = makeStyles({
+    container: {
+        display: 'flex',
+        width: '100%',
+    },
+    textColor: {
+      color: 'white', 
+      fontWeight: 'bold'
+    },
+    textColorHistoric: {
+      fontWeight: 'bold'
+    },
+    tableCellContent: {
+      maxWidth: '10vw'
+    },
+    header:{
+      display: 'flex',
+      justifyContent: 'space-between'
+    },
+    button: {
+      height: '2rem',
+      marginTop: '1.5rem'
+    },
+  });

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -79,25 +79,25 @@ export const proyectosEnCurso = [
     nombre: 'The Phantom Menace',
     director: 'George Lucas',
     fechaInicio: '08-07-1999',
-    porcentaje: '98%',
+    porcentaje: 98,
   },
   {
     nombre: 'A New Hope',
     director: 'George Lucas',
     fechaInicio: '25-12-1977',
-    porcentaje: '52%',
+    porcentaje: 52,
   },
   {
     nombre: 'The Force Awakens',
     director: 'J.J. Abrahams',
     fechaInicio: '17-12-2015',
-    porcentaje: '32%',
+    porcentaje: 32,
   },
   {
     nombre: 'Rogue One',
     director: 'Gareth Edwards',
     fechaInicio: '15-12-2016',
-    porcentaje: '47%',
+    porcentaje: 47,
   },
 ];
 
@@ -106,26 +106,26 @@ export const proyectosEnHistoria = [
     nombre: 'Attack of the Clones',
     director: 'George Lucas',
     fechaInicio: '16-05-2002',
-    porcentaje: '100%',
+    porcentaje: 100,
   },
   {
     nombre:
       'It is a dark time for the Rebellion. Although the Death Star has been destroyed, Imperial troops have driven the Rebel forces from their hidden base and pursued them across the galaxy',
     director: 'George Lucas',
     fechaInicio: '25-12-1977',
-    porcentaje: '100%',
+    porcentaje: 100,
   },
   {
     nombre: 'The Last Jedi',
     director: 'Rian Johnson',
     fechaInicio: '14-12-2017',
-    porcentaje: '100%',
+    porcentaje: 100,
   },
   {
     nombre: 'Solo',
     director: 'Ron Howard',
     fechaInicio: '24-05-2018',
-    porcentaje: '100%',
+    porcentaje: 100,
   },
 ];
 
@@ -196,5 +196,36 @@ export const compras = [
     monto: '4000',
     estado: 'estado',
     factura: 'factura',
+  },
+];
+
+export const proveedoresRegistrados = [
+  {
+    nombre: 'Logística Santos',
+    rubro: 'Insumos',
+    telefono: '67384433',
+    mail: 'dasjkd@gmail.com',
+    cuit: '23-31289332-9',
+  },
+  {
+    nombre: 'Messi Rve',
+    rubro: 'Viáticos',
+    telefono: '86954345',
+    mail: 'jkhgjfhe@gmail.com',
+    cuit: '20-34728353-4',
+  },
+  {
+    nombre: 'Ya no se me ocurre',
+    rubro: 'Bibliografía',
+    telefono: '52897353',
+    mail: 'fkdasjdkf@gmail.com',
+    cuit: '27-23786542-9',
+  },
+  {
+    nombre: 'Posta que no se que poner',
+    rubro: 'Relleno',
+    telefono: '31267323',
+    mail: 'dakhf-dasji@gmail.com',
+    cuit: '22-52452412-5',
   },
 ];

--- a/src/services/proveedores.js
+++ b/src/services/proveedores.js
@@ -1,0 +1,5 @@
+import { proveedoresRegistrados } from '../constants/constants';
+
+export async function getProveedores() {
+  return Promise.resolve(proveedoresRegistrados);
+}


### PR DESCRIPTION
Momentaneamente está como un gráfico circular, si les copa lo dejamos, sino bueno, a experimentar con el componente LinearProgress de Material UI, pero sinceramente, era más rápido sacarlo con CircularProgress y listo.

![progress](https://user-images.githubusercontent.com/46464403/140858294-3ff2281f-55c6-455b-8c30-c415ee0fd1e1.png)


Para la pantalla de Proveedores cree un componente PopUpProveedores y renombré el de compras a PopUpCompras, actualmente el PopUpProveedores es solo un copypaste del otro popup, pero bueno, al menos está para mostrar la interacción.

![proveedores](https://user-images.githubusercontent.com/46464403/140858285-049e5f2c-04b0-44ad-b57b-e7b7358ba8bc.png)
